### PR TITLE
Replace _S_VERSION constant when generating _s

### DIFF
--- a/plugins/underscoresme-generator/class-underscoresme-generator.php
+++ b/plugins/underscoresme-generator/class-underscoresme-generator.php
@@ -263,6 +263,7 @@ class Underscoresme_Generator {
 
 		// Regular treatment for all other files.
 		$contents = str_replace( '@package _s', sprintf( '@package %s', str_replace( ' ', '_', $this->theme['name'] ) ), $contents ); // Package declaration.
+		$contents = str_replace( '_S_', sprintf( '%s_', strtoupper( $this->theme['slug'] ) ), $contents ); // Verion constant.
 		$contents = str_replace( '_s-', sprintf( '%s-', $this->theme['slug'] ), $contents ); // Script/style handles.
 		$contents = str_replace( "'_s'", sprintf( "'%s'", $this->theme['slug'] ), $contents ); // Textdomains.
 		$contents = str_replace( '_s_', $slug . '_', $contents ); // Function names.


### PR DESCRIPTION
https://github.com/Automattic/_s/pull/1388 adds the constant `_S_VERSION` which get passed to `wp_enqueue_style` and `wp_enqueue_script` as the `$version` parameter. 

This PR take carer of replacing `_S_VERSION` when generating `_s`.